### PR TITLE
Fix type resolution for server build

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "@types/node": "^18.16.0",
     "@types/react": "^18.2.6",
     "@types/react-dom": "^18.2.4",
+    "@types/uuid": "^9.0.0",
+    "@types/pg": "^8.10.0",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "autoprefixer": "^10.4.14",

--- a/src/lib/realtime.ts
+++ b/src/lib/realtime.ts
@@ -1,3 +1,4 @@
+/// <reference types="vite/client" />
 import Ably from 'ably';
 
 export function subscribeResults(groupId: string, callback: () => void) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "types": ["node", "react", "react-dom"],
+    "types": ["node", "react", "react-dom", "vite/client"],
+    "typeRoots": ["./types", "./node_modules/@types"],
     "baseUrl": "."
   },
   "include": ["src", "netlify/functions"]

--- a/types/pg.d.ts
+++ b/types/pg.d.ts
@@ -1,0 +1,6 @@
+declare module 'pg' {
+  export class Pool {
+    constructor(config?: any);
+    query<T = any>(text: string, params?: any[]): Promise<{ rows: T[] }>;
+  }
+}

--- a/types/uuid.d.ts
+++ b/types/uuid.d.ts
@@ -1,0 +1,3 @@
+declare module 'uuid' {
+  export function v4(): string;
+}


### PR DESCRIPTION
## Summary
- declare modules for `uuid` and `pg` so server functions have typings
- include Vite client types so `import.meta.env` is typed
- reference Vite types in realtime helper

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e07db8470832d8cd83e4c0812b9ef