### PR TITLE
Add API redirect for Netlify functions

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,6 +6,11 @@
   directory = "netlify/functions"
 
 [[redirects]]
+  from = "/api/*"
+  to = "/.netlify/functions/:splat"
+  status = 200
+
+[[redirects]]
   from = "/*"
   to = "/index.html"
   status = 200


### PR DESCRIPTION
## Summary
- route `/api/*` to Netlify functions to expose join and other endpoints

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, require statements)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e0a5bbcec832d89e7bc6e0f40a2d7