### PR TITLE
Fix schema path for database migrations

### DIFF
--- a/netlify/functions/_db.ts
+++ b/netlify/functions/_db.ts
@@ -7,7 +7,7 @@ let migrated = false;
 
 export async function query<T extends QueryResultRow = QueryResultRow>(
   text: string,
-  params?: any[]
+  params?: unknown[]
 ): Promise<QueryResult<T>> {
   return pool.query<T>(text, params);
 }
@@ -16,7 +16,7 @@ export async function ensureMigrations() {
   if (migrated) return;
   const res = await pool.query("SELECT to_regclass('public.participants') as exists");
   if (!res.rows[0].exists) {
-    const schemaPath = path.resolve(__dirname, '../db/schema.sql');
+    const schemaPath = path.resolve(__dirname, '../../db/schema.sql');
     const sql = fs.readFileSync(schemaPath, 'utf8');
     await pool.query(sql);
   }


### PR DESCRIPTION
## Summary
- fix path to database schema to ensure migrations can run
- use unknown[] for query params to satisfy lint rules

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, no-var-requires, etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e0c189180832d9af954feb9ddf3c9