### PR TITLE
Fix grouping query ordering column

### DIFF
--- a/netlify/functions/_grouping.ts
+++ b/netlify/functions/_grouping.ts
@@ -23,10 +23,10 @@ function pickTreatment(): string {
 }
 
 export async function attemptGrouping() {
-  const res = await query<Participant>(`SELECT p.id, p.faculty FROM participants p
-    LEFT JOIN members m ON p.id = m.participant_id
-    WHERE m.participant_id IS NULL
-    ORDER BY p.joined_at ASC`);
+    const res = await query<Participant>(`SELECT p.id, p.faculty FROM participants p
+      LEFT JOIN members m ON p.id = m.participant_id
+      WHERE m.participant_id IS NULL
+      ORDER BY p.created_at ASC`);
   const waiting = res.rows;
   while (waiting.length >= 4) {
     const groupId = uuidv4();


### PR DESCRIPTION
## Summary
- use `created_at` instead of nonexistent `joined_at` when selecting waiting participants for grouping

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, no-var-requires)*

------
https://chatgpt.com/codex/tasks/task_e_689e0dc42400832d9018e762613fb29d