### PR TITLE
Add in-memory data layer and pairing logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "preview": "vite preview",
     "format": "prettier -w .",
     "lint": "eslint .",
-    "test": "echo \"No tests\""
+    "test": "tsc tests/pairing.test.ts --module commonjs --target es2019 --outDir build-tests --esModuleInterop && node --test build-tests/tests/pairing.test.js"
   },
   "dependencies": {
     "ably": "^1.2.23",

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -1,0 +1,41 @@
+import type { Participant, Pair, DecisionRecord, Outcome, Session } from '../types/models';
+
+type Key = string;
+
+class Table<T extends { id: Key }> {
+  private items = new Map<Key, T>();
+
+  async bulkPut(records: T[]): Promise<void> {
+    records.forEach(r => this.items.set(r.id, r));
+  }
+
+  async put(record: T): Promise<void> {
+    this.items.set(record.id, record);
+  }
+
+  where<K extends keyof T>(field: K) {
+    return {
+      equals: (value: T[K]) => ({
+        toArray: async () => Array.from(this.items.values()).filter(r => r[field] === value),
+      }),
+    };
+  }
+
+  async get(id: Key): Promise<T | undefined> {
+    return this.items.get(id);
+  }
+
+  async toArray(): Promise<T[]> {
+    return Array.from(this.items.values());
+  }
+}
+
+export class InMemoryDB {
+  participants = new Table<Participant>();
+  pairs = new Table<Pair>();
+  decisions = new Table<DecisionRecord>();
+  outcomes = new Table<Outcome>();
+  sessions = new Table<Session>();
+}
+
+export const db = new InMemoryDB();

--- a/src/services/decision.ts
+++ b/src/services/decision.ts
@@ -1,0 +1,36 @@
+import { v4 as uuidv4 } from 'uuid';
+import { db } from './db';
+import type { Decision, DecisionRecord, Outcome, Pair, Session } from '../types/models';
+
+export async function recordDecision(
+  session: Session,
+  pair: Pair,
+  participantId: string,
+  decision: Decision
+): Promise<void> {
+  const record: DecisionRecord = {
+    id: uuidv4(),
+    sessionId: session.id,
+    pairId: pair.id,
+    participantId,
+    decision,
+    decidedAt: Date.now(),
+  };
+  await db.decisions.put(record);
+
+  const decisions = await db.decisions.where('pairId').equals(pair.id).toArray();
+  const accepts = decisions.filter(d => d.decision === 'ACCEPT').length;
+  const implemented = accepts > 0;
+  if (decisions.length === 2) {
+    const outcome: Outcome = {
+      id: uuidv4(),
+      sessionId: session.id,
+      pairId: pair.id,
+      payoffA: implemented ? session.params.payoffs.accept_any[0] : session.params.payoffs.reject_all[0],
+      payoffB: implemented ? session.params.payoffs.accept_any[1] : session.params.payoffs.reject_all[1],
+      payoffVictim: implemented ? session.params.payoffs.accept_any[2] : session.params.payoffs.reject_all[2],
+      implemented,
+    };
+    await db.outcomes.put(outcome);
+  }
+}

--- a/src/services/pairing.ts
+++ b/src/services/pairing.ts
@@ -1,0 +1,72 @@
+import { v4 as uuidv4 } from 'uuid';
+import { db } from './db';
+import type { Participant, Pair, Session } from '../types/models';
+import { createRNG } from '../utils/rng';
+
+function shuffle<T>(arr: T[], rng: () => number): T[] {
+  const copy = [...arr];
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy;
+}
+
+export async function pairParticipants(session: Session, participants: Participant[]): Promise<Pair[]> {
+  const rng = createRNG(session.seed);
+  const human = participants.filter(p => p.exp_academic_unit === 1);
+  const ing = participants.filter(p => p.exp_academic_unit === 2);
+  const other = participants.filter(p => p.exp_academic_unit === 3);
+
+  const pairs: Pair[] = [];
+
+  function createPairs(group: Participant[], type: 'human' | 'ing'): void {
+    const shuffled = shuffle(group, rng);
+    for (let i = 0; i + 1 < shuffled.length; i += 2) {
+      const [a, b] = [shuffled[i], shuffled[i + 1]];
+      const tRand = rng();
+      let treatment: 'T1' | 'T2' | 'T3' | 'T4';
+      if (type === 'human') {
+        treatment = tRand < session.params.t1_prob ? 'T1' : 'T2';
+      } else {
+        treatment = tRand < session.params.t3_prob ? 'T3' : 'T4';
+      }
+      const victim_group = treatment === 'T1' || treatment === 'T3' ? 'HUMANAS' : 'INGENIERIAS';
+      pairs.push({
+        id: uuidv4(),
+        sessionId: session.id,
+        treatment,
+        participantAId: a.id,
+        participantBId: b.id,
+        victim_group,
+        round: 1,
+      });
+    }
+  }
+
+  createPairs(human, 'human');
+  createPairs(ing, 'ing');
+
+  const leftovers: Participant[] = [];
+  if (human.length % 2 === 1) leftovers.push(human[human.length - 1]);
+  if (ing.length % 2 === 1) leftovers.push(ing[ing.length - 1]);
+  leftovers.push(...other);
+
+  const shuffledLeft = shuffle(leftovers, rng);
+  for (let i = 0; i + 1 < shuffledLeft.length; i += 2) {
+    const [a, b] = [shuffledLeft[i], shuffledLeft[i + 1]];
+    const victim_group = rng() < 0.5 ? 'HUMANAS' : 'INGENIERIAS';
+    pairs.push({
+      id: uuidv4(),
+      sessionId: session.id,
+      treatment: 'T5',
+      participantAId: a.id,
+      participantBId: b.id,
+      victim_group,
+      round: 1,
+    });
+  }
+
+  await db.pairs.bulkPut(pairs);
+  return pairs;
+}

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -1,0 +1,70 @@
+export type AcademicUnitRaw = 0 | 1 | 2 | 3 | 4;
+export type ExpAcademicUnit = 1 | 2 | 3; // 1=Humanas, 2=Ingenierías, 3=Otras
+export type Treatment = 'T1' | 'T2' | 'T3' | 'T4' | 'T5';
+export type Decision = 'ACCEPT' | 'REJECT';
+
+export interface Participant {
+  id: string;
+  sessionId: string;
+  academic_unit: AcademicUnitRaw;
+  exp_academic_unit: ExpAcademicUnit;
+  createdAt: number;
+}
+
+export interface Pair {
+  id: string;
+  sessionId: string;
+  treatment: Treatment;
+  participantAId: string;
+  participantBId: string;
+  victim_group: 'HUMANAS' | 'INGENIERIAS';
+  victim_id?: string;
+  round: number;
+}
+
+export interface DecisionRecord {
+  id: string;
+  sessionId: string;
+  pairId: string;
+  participantId: string;
+  decision: Decision;
+  decidedAt: number;
+}
+
+export interface Outcome {
+  id: string;
+  sessionId: string;
+  pairId: string;
+  payoffA: number;
+  payoffB: number;
+  payoffVictim: number;
+  implemented: boolean;
+}
+
+export interface SessionParams {
+  t1_prob: number;
+  t2_prob: number;
+  t3_prob: number;
+  t4_prob: number;
+  t5_enabled: boolean;
+  victim_selection: 'random' | 'none';
+  payoffs: {
+    reject_all: [number, number, number];
+    accept_any: [number, number, number];
+  };
+}
+
+export interface Session {
+  id: string;
+  name: string;
+  seed: string;
+  createdAt: number;
+  params: SessionParams;
+}
+
+// Helper for mapping academic_unit to experimental groups
+export function mapAcademicUnit(unit: AcademicUnitRaw): ExpAcademicUnit {
+  if (unit === 1) return 1;
+  if (unit === 2 || unit === 3) return 2;
+  return 3; // Ciencias (0) or Salud (4)
+}

--- a/src/utils/rng.ts
+++ b/src/utils/rng.ts
@@ -1,0 +1,13 @@
+export function createRNG(seed: string): () => number {
+  let h = 1779033703 ^ seed.length;
+  for (let i = 0; i < seed.length; i++) {
+    h = Math.imul(h ^ seed.charCodeAt(i), 3432918353);
+    h = (h << 13) | (h >>> 19);
+  }
+  return function () {
+    h = Math.imul(h ^ (h >>> 16), 2246822507);
+    h = Math.imul(h ^ (h >>> 13), 3266489909);
+    const t = (h ^= h >>> 16) >>> 0;
+    return t / 4294967296;
+  };
+}

--- a/tests/pairing.test.ts
+++ b/tests/pairing.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { mapAcademicUnit } from '../src/types/models';
+import { pairParticipants } from '../src/services/pairing';
+import { db } from '../src/services/db';
+import { v4 as uuidv4 } from 'uuid';
+import type { Participant, Session } from '../src/types/models';
+
+test('map academic unit', () => {
+  assert.equal(mapAcademicUnit(1), 1);
+  assert.equal(mapAcademicUnit(2), 2);
+  assert.equal(mapAcademicUnit(3), 2);
+  assert.equal(mapAcademicUnit(0), 3);
+  assert.equal(mapAcademicUnit(4), 3);
+});
+
+test('pairing produces treatments', async () => {
+  const session: Session = {
+    id: uuidv4(),
+    name: 's1',
+    seed: 'seed',
+    createdAt: Date.now(),
+    params: {
+      t1_prob: 1,
+      t2_prob: 0,
+      t3_prob: 1,
+      t4_prob: 0,
+      t5_enabled: true,
+      victim_selection: 'random',
+      payoffs: {
+        reject_all: [100, 100, 100],
+        accept_any: [120, 120, 60],
+      },
+    },
+  };
+
+  const participants: Participant[] = [
+    { id: uuidv4(), sessionId: session.id, academic_unit: 1, exp_academic_unit: 1, createdAt: 0 },
+    { id: uuidv4(), sessionId: session.id, academic_unit: 1, exp_academic_unit: 1, createdAt: 0 },
+    { id: uuidv4(), sessionId: session.id, academic_unit: 2, exp_academic_unit: 2, createdAt: 0 },
+    { id: uuidv4(), sessionId: session.id, academic_unit: 2, exp_academic_unit: 2, createdAt: 0 },
+  ];
+
+  await db.participants.bulkPut(participants);
+  const pairs = await pairParticipants(session, participants);
+  assert.equal(pairs.length, 2);
+  assert.equal(pairs[0].treatment, 'T1');
+  assert.equal(pairs[1].treatment, 'T3');
+});


### PR DESCRIPTION
## Summary
- add TypeScript models for participants, sessions, pairs, and outcomes
- implement in-memory Dexie-like database and deterministic pairing/decision services
- add node-based tests validating group mapping and pairing treatments

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a60d9787dc832da1b2481c303aaf51