### PR TITLE
feat: show full faculty list for participant registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.14.1",
     "uuid": "^9.0.0",
-    "pg": "^8.11.0"
+    "pg": "^8.11.0",
+    "react-hook-form": "^7.45.1"
   },
   "devDependencies": {
     "@netlify/functions": "^1.6.0",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,7 +1,12 @@
-export async function join(faculty: string) {
+import type { AcademicUnitRaw } from '../types/models';
+import { toExpGroup } from '../types/models';
+
+export async function join(academicUnit: AcademicUnitRaw) {
   const pid = crypto.randomUUID();
   localStorage.setItem('participant_id', pid);
-  localStorage.setItem('faculty', faculty);
+  localStorage.setItem('academic_unit', academicUnit.toString());
+  const exp = toExpGroup(academicUnit);
+  localStorage.setItem('exp_academic_unit', exp.toString());
   localStorage.setItem('status', 'decision');
   localStorage.setItem('role', 'negotiator1');
   return { participant_id: pid };

--- a/src/pages/ConsentFaculty.tsx
+++ b/src/pages/ConsentFaculty.tsx
@@ -1,51 +1,70 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useForm, Controller } from 'react-hook-form';
 import { join } from '../lib/api';
+import { FACULTIES, AcademicUnitRaw } from '../types/models';
+
+interface FormData {
+  academic_unit: AcademicUnitRaw | '';
+  consent: boolean;
+}
 
 export default function ConsentFaculty() {
-  const [faculty, setFaculty] = useState('ingenierias');
-  const [consent, setConsent] = useState(false);
   const navigate = useNavigate();
+  const { control, handleSubmit, watch } = useForm<FormData>({
+    defaultValues: { academic_unit: '', consent: false },
+  });
 
-  const onSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    const res = await join(faculty);
+  const consent = watch('consent');
+
+  const onSubmit = async (values: FormData) => {
+    const res = await join(Number(values.academic_unit) as AcademicUnitRaw);
     navigate(`/waiting?pid=${encodeURIComponent(res.participant_id)}`);
   };
 
   return (
-    <form onSubmit={onSubmit} className="space-y-4">
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
       <p className="text-sm">
         Este estudio es anónimo y con fines académicos. Puedes retirarte en cualquier momento.
       </p>
       <label className="block">
         <span className="block mb-1">Facultad</span>
-        <select
-          className="border p-2 w-full"
-          value={faculty}
-          onChange={(e) => setFaculty(e.target.value)}
-          required
-        >
-          <option value="ingenierias">Ingenierías</option>
-          <option value="humanidades">Humanidades</option>
-          <option value="neutral">Otra/Neutral</option>
-        </select>
+        <Controller
+          name="academic_unit"
+          control={control}
+          rules={{ required: true }}
+          render={({ field }) => (
+            <select
+              {...field}
+              className="border p-2 w-full"
+            >
+              <option value="" disabled>
+                Seleccione su facultad…
+              </option>
+              {FACULTIES.map((f) => (
+                <option key={f.value} value={f.value}>
+                  {f.label}
+                </option>
+              ))}
+            </select>
+          )}
+        />
       </label>
       <label className="flex items-center space-x-2">
-        <input
-          type="checkbox"
-          checked={consent}
-          onChange={(e) => setConsent(e.target.checked)}
+        <Controller
+          name="consent"
+          control={control}
+          render={({ field }) => <input type="checkbox" {...field} />}
         />
         <span>Acepto participar</span>
       </label>
       <button
-        type="submit"
-        disabled={!consent}
-        className="bg-blue-600 text-white px-4 py-2 rounded disabled:opacity-50"
-      >
-        Continuar
-      </button>
+      type="submit"
+      disabled={!consent}
+      className="bg-blue-600 text-white px-4 py-2 rounded disabled:opacity-50"
+    >
+      Continuar
+    </button>
     </form>
   );
 }

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -1,4 +1,12 @@
 export type AcademicUnitRaw = 0 | 1 | 2 | 3 | 4;
+export const FACULTIES: { value: AcademicUnitRaw; label: string }[] = [
+  { value: 0, label: 'Facultad de Ciencias' },
+  { value: 1, label: 'Facultad de Ciencias Humanas' },
+  { value: 2, label: 'Facultad de Ingenierías Fisicomecánicas' },
+  { value: 3, label: 'Facultad de Ingenierías Fisicoquímicas' },
+  { value: 4, label: 'Facultad de Salud' },
+];
+
 export type ExpAcademicUnit = 1 | 2 | 3; // 1=Humanas, 2=Ingenierías, 3=Otras
 export type Treatment = 'T1' | 'T2' | 'T3' | 'T4' | 'T5';
 export type Decision = 'ACCEPT' | 'REJECT';
@@ -63,8 +71,11 @@ export interface Session {
 }
 
 // Helper for mapping academic_unit to experimental groups
-export function mapAcademicUnit(unit: AcademicUnitRaw): ExpAcademicUnit {
+export function toExpGroup(unit: AcademicUnitRaw): ExpAcademicUnit {
   if (unit === 1) return 1;
   if (unit === 2 || unit === 3) return 2;
   return 3; // Ciencias (0) or Salud (4)
 }
+
+// Backwards compatibility alias
+export const mapAcademicUnit = toExpGroup;

--- a/tests/pairing.test.ts
+++ b/tests/pairing.test.ts
@@ -1,17 +1,17 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { mapAcademicUnit } from '../src/types/models';
+import { toExpGroup } from '../src/types/models';
 import { pairParticipants } from '../src/services/pairing';
 import { db } from '../src/services/db';
 import { v4 as uuidv4 } from 'uuid';
 import type { Participant, Session } from '../src/types/models';
 
 test('map academic unit', () => {
-  assert.equal(mapAcademicUnit(1), 1);
-  assert.equal(mapAcademicUnit(2), 2);
-  assert.equal(mapAcademicUnit(3), 2);
-  assert.equal(mapAcademicUnit(0), 3);
-  assert.equal(mapAcademicUnit(4), 3);
+  assert.equal(toExpGroup(1), 1);
+  assert.equal(toExpGroup(2), 2);
+  assert.equal(toExpGroup(3), 2);
+  assert.equal(toExpGroup(0), 3);
+  assert.equal(toExpGroup(4), 3);
 });
 
 test('pairing produces treatments', async () => {


### PR DESCRIPTION
## Summary
- add FACULTIES constants and helper to map academic unit to experiment group
- update join logic and consent form to store academic unit and show full faculty list
- cover mapping with updated tests

## Testing
- `node --test build-tests/tests/pairing.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a613d472bc832dabf1b4c5a73cdb76