### PR TITLE
Fix checkbox field type in ConsentFaculty

### DIFF
--- a/src/pages/ConsentFaculty.tsx
+++ b/src/pages/ConsentFaculty.tsx
@@ -54,7 +54,16 @@ export default function ConsentFaculty() {
         <Controller
           name="consent"
           control={control}
-          render={({ field }) => <input type="checkbox" {...field} />}
+          render={({ field: { value, onChange, onBlur, name, ref } }) => (
+            <input
+              type="checkbox"
+              checked={value}
+              onChange={onChange}
+              onBlur={onBlur}
+              name={name}
+              ref={ref}
+            />
+          )}
         />
         <span>Acepto participar</span>
       </label>


### PR DESCRIPTION
## Summary
- fix consent checkbox to use `checked` prop instead of `value`

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a622e3ab20832db2e1d6817f3f5d1c