### PR TITLE
Add student code and admin scoring module

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, Link } from 'react-router-dom';
 import ConsentFaculty from './pages/ConsentFaculty';
 import Waiting from './pages/Waiting';
 import Decision from './pages/Decision';
@@ -13,6 +13,11 @@ export default function App() {
     <div className="max-w-xl mx-auto p-4">
       <header className="text-center mb-4">
         <h1 className="text-xl font-bold">Grupo EMAR – UIS</h1>
+        <div className="mt-2">
+          <Link to="/admin" className="text-sm underline">
+            Admin
+          </Link>
+        </div>
       </header>
       <Routes>
         <Route path="/" element={<ConsentFaculty />} />

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,37 +1,90 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { getRecords, SavedRecord } from '../lib/api';
+
+function downloadCsv(records: SavedRecord[], filename: string) {
+  const headers: (keyof SavedRecord)[] = [
+    'code',
+    'academic_unit',
+    'decision',
+    'rating',
+    'payoff_n1',
+    'payoff_n2',
+    'payoff_victim',
+    'payoff_observer',
+  ];
+  const rows = records.map((r) =>
+    headers
+      .map((h) => {
+        const value = r[h] ?? '';
+        return typeof value === 'string' ? `"${value}"` : value;
+      })
+      .join(',')
+  );
+  const csv = [headers.join(','), ...rows].join('\n');
+  const blob = new Blob([csv], { type: 'text/csv' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
 
 export default function Admin() {
-  const [token, setToken] = useState('');
+  const [records, setRecords] = useState<SavedRecord[]>([]);
 
-  const exportCsv = async () => {
-    const res = await fetch('/api/export?format=csv', {
-      headers: { Authorization: `Bearer ${token}` },
-    });
-    if (res.ok) {
-      const blob = await res.blob();
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = 'export.csv';
-      a.click();
-      URL.revokeObjectURL(url);
-    } else {
-      alert('Error');
-    }
-  };
+  useEffect(() => {
+    setRecords(getRecords());
+  }, []);
+
+  const exportAll = () => downloadCsv(records, 'records.csv');
+  const exportOne = (r: SavedRecord) => downloadCsv([r], `record_${r.code}.csv`);
 
   return (
     <div className="space-y-4">
-      <input
-        type="password"
-        value={token}
-        onChange={(e) => setToken(e.target.value)}
-        placeholder="Token"
-        className="border p-2 w-full"
-      />
-      <button className="bg-blue-600 text-white px-4 py-2 rounded" onClick={exportCsv}>
-        Exportar CSV
+      <button
+        className="bg-blue-600 text-white px-4 py-2 rounded"
+        onClick={exportAll}
+      >
+        Exportar todo
       </button>
+      <table className="w-full border text-sm">
+        <thead>
+          <tr>
+            <th className="border px-2">Código</th>
+            <th className="border px-2">Facultad</th>
+            <th className="border px-2">Decisión</th>
+            <th className="border px-2">Rating</th>
+            <th className="border px-2">N1</th>
+            <th className="border px-2">N2</th>
+            <th className="border px-2">Víctima</th>
+            <th className="border px-2">Observador</th>
+            <th className="border px-2">Exportar</th>
+          </tr>
+        </thead>
+        <tbody>
+          {records.map((r) => (
+            <tr key={r.code}>
+              <td className="border px-2">{r.code}</td>
+              <td className="border px-2">{r.academic_unit}</td>
+              <td className="border px-2">{r.decision}</td>
+              <td className="border px-2">{r.rating ?? ''}</td>
+              <td className="border px-2">{r.payoff_n1}</td>
+              <td className="border px-2">{r.payoff_n2}</td>
+              <td className="border px-2">{r.payoff_victim}</td>
+              <td className="border px-2">{r.payoff_observer}</td>
+              <td className="border px-2 text-center">
+                <button
+                  className="underline text-blue-600"
+                  onClick={() => exportOne(r)}
+                >
+                  CSV
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/src/pages/ConsentFaculty.tsx
+++ b/src/pages/ConsentFaculty.tsx
@@ -5,6 +5,7 @@ import { join } from '../lib/api';
 import { FACULTIES, AcademicUnitRaw } from '../types/models';
 
 interface FormData {
+  student_code: string;
   academic_unit: AcademicUnitRaw | '';
   consent: boolean;
 }
@@ -12,13 +13,18 @@ interface FormData {
 export default function ConsentFaculty() {
   const navigate = useNavigate();
   const { control, handleSubmit, watch } = useForm<FormData>({
-    defaultValues: { academic_unit: '', consent: false },
+    defaultValues: { student_code: '', academic_unit: '', consent: false },
   });
 
   const consent = watch('consent');
+  const academic = watch('academic_unit');
+  const code = watch('student_code');
 
   const onSubmit = async (values: FormData) => {
-    const res = await join(Number(values.academic_unit) as AcademicUnitRaw);
+    const res = await join(
+      Number(values.academic_unit) as AcademicUnitRaw,
+      values.student_code
+    );
     navigate(`/waiting?pid=${encodeURIComponent(res.participant_id)}`);
   };
 
@@ -27,6 +33,17 @@ export default function ConsentFaculty() {
       <p className="text-sm">
         Este estudio es anónimo y con fines académicos. Puedes retirarte en cualquier momento.
       </p>
+      <label className="block">
+        <span className="block mb-1">Código estudiantil</span>
+        <Controller
+          name="student_code"
+          control={control}
+          rules={{ required: true }}
+          render={({ field }) => (
+            <input {...field} className="border p-2 w-full" />
+          )}
+        />
+      </label>
       <label className="block">
         <span className="block mb-1">Facultad</span>
         <Controller
@@ -69,7 +86,7 @@ export default function ConsentFaculty() {
       </label>
       <button
       type="submit"
-      disabled={!consent}
+      disabled={!consent || !academic || !code}
       className="bg-blue-600 text-white px-4 py-2 rounded disabled:opacity-50"
     >
       Continuar

--- a/src/pages/Decision.tsx
+++ b/src/pages/Decision.tsx
@@ -14,6 +14,11 @@ export default function Decision() {
 
   return (
     <div className="space-y-4 text-center">
+      <p>
+        Tienes 100 puntos y estás negociando un trato. Si aceptas, ambos se van con
+        120 puntos y la otra persona se va con 60. Si ambos lo rechazan, todos se
+        quedan con sus 100 puntos.
+      </p>
       <p>Elige tu decisión:</p>
       <div className="flex justify-center space-x-4">
         <button

--- a/src/pages/End.tsx
+++ b/src/pages/End.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { groupStatus, GroupResults } from '../lib/api';
+import { groupStatus, GroupResults, finalizeRecord } from '../lib/api';
 
 export default function End() {
   const [params] = useSearchParams();
@@ -22,6 +22,7 @@ export default function End() {
             ? r.payoff_victim
             : r.payoff_observer;
         setPayoff(p);
+        finalizeRecord();
       }
     };
     load();


### PR DESCRIPTION
## Summary
- Add student code input and require it to continue
- Introduce local record storage and admin dashboard with CSV export
- Display payoff negotiation legend in decision screen

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6253622b8832dbbe5aef34b9cb31a